### PR TITLE
Org statuses were in the incorrect graph

### DIFF
--- a/config/consumer/op/util.js
+++ b/config/consumer/op/util.js
@@ -167,6 +167,7 @@ async function moveToPublic(muUpdate, endpoint) {
   await moveTypeToPublic(muUpdate, endpoint, 'org:ChangeEvent')
   await moveTypeToPublic(muUpdate, endpoint, 'code:VeranderingsgebeurtenisResultaat')
   await moveTypeToPublic(muUpdate, endpoint, 'code:Veranderingsgebeurtenis')
+  await moveTypeToPublic(muUpdate, endpoint, 'code:OrganisatieStatusCode')
 }
 
 async function moveTypeToPublic(muUpdate, endpoint, type) {


### PR DESCRIPTION
They were appearing due to a bug in the mu-auth version we were using, now that that bug is fixed we need to move them to the correct graph