### PR TITLE
Add migration to change to andere vesitiging

### DIFF
--- a/config/migrations/20240703122600-migrate-to-andere-vestiging.sparql
+++ b/config/migrations/20240703122600-migrate-to-andere-vestiging.sparql
@@ -1,0 +1,14 @@
+PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+DELETE {
+    GRAPH ?g {
+        ?site ere:vestigingstype <http://lblod.data.gift/concepts/fbec5e94aba343b0a7361aca8a0c7d79>.
+    }
+}INSERT {
+    GRAPH ?g {
+        ?site ere:vestigingstype <http://lblod.data.gift/concepts/dcc01338-842c-4fbd-ba68-3ca6f3af975c>.
+    }
+}WHERE {
+    GRAPH ?g {
+        ?site ere:vestigingstype <http://lblod.data.gift/concepts/fbec5e94aba343b0a7361aca8a0c7d79>.
+    }
+}


### PR DESCRIPTION
This migration changes the Ander administratief sites to andere vesitging in both DEV and QA, this is not needed in PROD as the wrong data is not there, but there's no harm to push it to PROD, so I made the migration. Should be deployed together with the frontend branch of the same name