### PR TITLE
Fix wrong route on the controle dispatcher

### DIFF
--- a/config/dispatcher/dispatcher-controle.ex
+++ b/config/dispatcher/dispatcher-controle.ex
@@ -161,8 +161,8 @@ defmodule Dispatcher do
   # Address search
   #################################################################
 
-  match "/address-search-add-on/*path" do
-    Proxy.forward conn, path, "http://address-search-add-on/"
+  match "/adresses-register/*path" do
+    forward conn, path, "http://adressenregister"
   end
 
     ###############################################################


### PR DESCRIPTION
Address search is not working on the controle, because of this route that was wrongly set