### PR TITLE
Fix Wrong total number of mock-login accounts displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # CHANGELOG
+## Unreleased
+- Fix mock-login accounts lists showing wrong total number [CLBV-1022]
+### Deploy notes
+```
+drc up -d resource
+```
 ## 1.9.1 (2025-05-08)
 - Workaround for strings with special characters not being properly deleted on update by the consumer [CLBV-1019]
 

--- a/config/resources/domain.lisp
+++ b/config/resources/domain.lisp
@@ -1,5 +1,7 @@
 (in-package :mu-cl-resources)
 
+(defparameter *include-count-in-paginated-responses* t)
+
 ;; reading in the domain.json
 (read-domain-file "domain.json")
 (read-domain-file "file-service.json")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
     restart: always
     logging: *default-logging
   resource:
-    image: semtech/mu-cl-resources:1.26.0
+    image: semtech/mu-cl-resources:1.27.0
     volumes:
       - ./config/resources:/config
     labels:


### PR DESCRIPTION
# Context

[CLBV-1022]

A parameter was missing in the mu-cl-resources configuration to get the total count of resources when a request is made. While I was at it, I also took the chance to bump the service.

# Test instructions

Run the stack locally with a copy of dev/prod/qa db, `drc up -d resource` and go to http://localhost:4200/mock-login . The total number of mock-login accounts should be a lot higher (i have  4988 locally, yours could be slightly different depending on the organizations you have locally).